### PR TITLE
Added missing deploy:set_shared_assets in flow example.

### DIFF
--- a/documentation/getting-started/flow/index.markdown
+++ b/documentation/getting-started/flow/index.markdown
@@ -63,6 +63,7 @@ deploy
   deploy:starting
     [before]
       deploy:ensure_stage
+      deploy:set_shared_assets
     deploy:check
   deploy:started
   deploy:updating


### PR DESCRIPTION
Added missing deploy:set_shared_assets in flow example.
