### PR TITLE
Correct spelling errors on What Is Capistrano

### DIFF
--- a/_site/documentation/overview/what-is-capistrano/index.html
+++ b/_site/documentation/overview/what-is-capistrano/index.html
@@ -112,7 +112,7 @@
 <p>Capistrano can be used to:</p>
 
 <ul>
-<li>Reliably deploy web application to any number of machines simultaniously,
+<li>Reliably deploy web application to any number of machines simultaneously,
 in sequence or as a rolling set</li>
 <li>To automate audits of any number of machines (checking login logs,
 enumerating uptimes, and/or applying security patches)</li>
@@ -220,7 +220,7 @@ task :ditty do
   end
 
   on roles(:app) do
-    # We can set environmental varaibles for the duration of a block
+    # We can set environmental variables for the duration of a block
     # and move the process into a directoy, executing arbitrary tasks
     # such as letting Rails do some heavy lifting.
     with({:rails_env =&gt; :production}) do


### PR DESCRIPTION
Fixed two spelling errors on [What is Capistrano?](http://www.capistranorb.com/documentation/overview/what-is-capistrano/)
