### PR TITLE
Fixed a small typo where 'tool' was spelt 'too'

### DIFF
--- a/_site/documentation/overview/what-is-capistrano/index.html
+++ b/_site/documentation/overview/what-is-capistrano/index.html
@@ -129,7 +129,7 @@ enumerating uptimes, and/or applying security patches)</li>
 </ul>
 
 <p>Capistrano is also <em>very</em> scriptable, and can be integrated with any other
-Ruby software to form part of a larger too.</p>
+Ruby software to form part of a larger tool.</p>
 
 <h4 id="toc_1">What does it look like?</h4>
 
@@ -285,7 +285,7 @@ enumerating uptimes, and/or applying security patches)</li>
 </ul>
 
 <p>Capistrano is also <em>very</em> scriptable, and can be integrated with any other
-Ruby software to form part of a larger too.</p>
+Ruby software to form part of a larger tool.</p>
 
 <h4 id="toc_1">What does it look like?</h4>
 

--- a/documentation/overview/what-is-capistrano/index.markdown
+++ b/documentation/overview/what-is-capistrano/index.markdown
@@ -18,7 +18,7 @@ Capistrano can be used to:
 * To drive infrastructure provisioning tools such as *chef-solo*, *Ansible* or similar.
 
 Capistrano is also *very* scriptable, and can be integrated with any other
-Ruby software to form part of a larger too.
+Ruby software to form part of a larger tool.
 
 #### What does it look like?
 


### PR DESCRIPTION
Thanks for writing up this great documentation.
