### PR TITLE
Fix role filtering documentation code examples.

### DIFF
--- a/documentation/getting-started/role-filtering/index.markdown
+++ b/documentation/getting-started/role-filtering/index.markdown
@@ -27,7 +27,9 @@ There are three ways to specify the role filter.
 Capistrano will read the role filter from the environment variable `ROLES`
 if it is set. You can set it inline:
 
+{% prism bash %}
     ROLES=app,web cap production deploy
+{% endprism %}
 
 Specify multiple roles by separating them with a comma.
 
@@ -36,7 +38,9 @@ Specify multiple roles by separating them with a comma.
 You can set the role filter inside your deploy configuration. For example,
 you can set the following inside `config/deploy.rb`:
 
+{% prism ruby %}
     set :filter, :roles => %w{app web}
+{% endprism %}
 
 Note that you specify the filter as an array rather than as a comma-separated
 list of roles when using this method.
@@ -46,7 +50,9 @@ list of roles when using this method.
 In a similar way to using the environment variable, you can set the role
 filter by specifying it as a command line argument to `cap`:
 
+{% prism bash %}
     cap --roles=app,web production deploy
+{% endprism %}
 
 Like the environment variable method, specify multiple roles by separating them
 with a comma.


### PR DESCRIPTION
The role filtering documentation code samples do not format properly on
the documentation website. This pull request fixes that.
