### PR TITLE
change meta 'role :all' to legal 'role :web'

### DIFF
--- a/documentation/getting-started/preparing-your-application/index.markdown
+++ b/documentation/getting-started/preparing-your-application/index.markdown
@@ -129,7 +129,7 @@ These host strings are parsed and expanded out in to the equivalent of the
 server line after the comment:
 
 {% prism ruby %}
-  role :all, %w{hello@world.com example.com:1234}
+  role :web, %w{hello@world.com example.com:1234}
   # ...is the same as doing...
   server 'world.com' roles: [:web], user: 'hello'
   server 'example.com', roles: [:web], port: 1234


### PR DESCRIPTION
This typo costed a lot of my time.
See https://github.com/capistrano/capistrano/pull/711 for more details.
