### PR TITLE
Left off a 'do' on the example

### DIFF
--- a/_posts/2013-06-01-release-announcement.markdown
+++ b/_posts/2013-06-01-release-announcement.markdown
@@ -340,7 +340,7 @@ In Capistrano v3 this looks more like this:
     # Capistrano 3.0.x
     task :precompile do
       on :sprockets_asset_host, reject: lambda { |h| h.properties.no_release } do
-        within fetch(:latest_release_directory)
+        within fetch(:latest_release_directory) do
           with rails_env: fetch(:rails_env) do
             execute :rake, 'assets:precompile'
           end


### PR DESCRIPTION
The Command Language example has a typo in it. Fixed.
