### PR TITLE
Doesn't cleanup assets after compiling them

### DIFF
--- a/documentation/getting-started/flow/index.markdown
+++ b/documentation/getting-started/flow/index.markdown
@@ -75,7 +75,6 @@ deploy
     [after]
       deploy:migrate
       deploy:compile_assets
-      deploy:cleanup_assets
       deploy:normalise_assets
   deploy:publishing
     deploy:symlink:release


### PR DESCRIPTION
I double checked in the code. It's there but commented out (I don't know why it's there at all.)
