### PR TITLE
Add password authentication tip to FAQ and navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -38,6 +38,7 @@
   <li class="divider"></li>
   <h5>FAQ</h5>
   <li><a href="/documentation/faq/why-does-something-work-in-my-ssh-session-but-not-in-capistrano/">Why Does Something Work In An SSH Session, But Not In Capistrano?</a></li>
+  <li><a href="/documentation/faq/how-can-i-get-capistrano-to-prompt-for-a-password/">How can I get Capistrano to prompt for a password?</a></li>
   <!--<li><a href="/documentation/faq/should-i-use-capistrano-to-provision-my-servers/">Should I Use Capistrano To Provision My Servers?</a></li>-->
   <li><a href="http://lee.hambley.name/2013/06/11/using-capistrano-v3-with-chef.html">Should I Use Capistrano To Provision My Servers?</a></li>
   <!--<li class="divider"></li>                                                                                                      -->

--- a/documentation/faq/how-can-i-get-capistrano-to-prompt-for-a-password/index.markdown
+++ b/documentation/faq/how-can-i-get-capistrano-to-prompt-for-a-password/index.markdown
@@ -1,0 +1,12 @@
+---
+title: How can I get Capistrano to prompt for a password?
+layout: default
+---
+
+Password authentication can be done via `set` and `ask` in your deploy environment file (e.g.: config/environments/production.rb)
+
+{% highlight ruby %}
+    # Capistrano 3.0.x
+		set :password, ask('Server password:', nil)
+		server 'server.domain.com', user: 'ssh_user_name', port: 22, password: fetch(:password), roles: %w{web app db}
+{% endhighlight %}


### PR DESCRIPTION
This PR adds a password authentication tip to FAQ, as said in this issue: https://github.com/capistrano/sshkit/issues/106
c/c: @leehambley
