### PR TITLE
Plugins page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -27,6 +27,7 @@
   <li><a href="/documentation/frameworks/ruby-on-rails/">Ruby on Rails</a></li>
   <li><a href="/documentation/frameworks/bundler/">Bundler</a></li>
   <li><a href="/documentation/frameworks/rbenv-rvm-chruby/">Rbenv &amp; RVM &amp; chruby</a></li>
+  <li><a href="/documentation/plugins/">Plugins</a></li>
   <!--<li class="divider"></li>                                                                     -->
   <!--<h5>Troubleshooting</h5>                                                                      -->
   <!--<li><a href="/documentation/troubleshooting/authentication/">SCM (Git) Authentication</a></li>-->

--- a/documentation/plugins/index.markdown
+++ b/documentation/plugins/index.markdown
@@ -1,0 +1,15 @@
+---
+title: Plugins
+layout: default
+---
+
+Here are some Capistrano plugins you might find useful.
+
+<div class="github-widget" data-repo="bruno-/capistrano-postgresql"></div>
+
+<div class="github-widget" data-repo="bruno-/capistrano-unicorn-nginx"></div>
+
+<div class="github-widget" data-repo="bruno-/capistrano-rbenv-install"></div>
+
+<div class="github-widget" data-repo="bruno-/capistrano-safe-deploy-to"></div>
+


### PR DESCRIPTION
Based on a discussion with Lee [here](https://groups.google.com/d/msg/capistrano/ZFWVxOzsOZI/jJ7KFvAYjWcJ).

This pull request adds a plugins page under the 'Framework Extensions' nav section. First 4 plugins are added to the page.

![screen shot 2014-04-18 at 12 04 52 am](https://cloud.githubusercontent.com/assets/1042682/2737503/56b30974-c67c-11e3-99a1-269a67c000fa.png)
