### PR TITLE
Added ':' after the Personal Access Token in Github URL

### DIFF
--- a/documentation/getting-started/authentication-and-authorisation/index.markdown
+++ b/documentation/getting-started/authentication-and-authorisation/index.markdown
@@ -286,12 +286,12 @@ Tokens](https://github.com/blog/1509-personal-api-tokens) which allow you to
 do something like this:
 
 {% highlight bash %}
-    me@localhost $ git ls-remote https://.....................@github.com/capistrano/rails3-bootstrap-devise-cancan.git
+    me@localhost $ git ls-remote https://XXXX:@github.com/capistrano/rails3-bootstrap-devise-cancan.git
     3419812c9f146d9a84b44bcc2c3caef94da54758HEAD
     3419812c9f146d9a84b44bcc2c3caef94da54758HEADrefs/heads/master
 {% endhighlight %}
 
-Where `....` is a personal API token, as such:
+Where `XXXX` is a personal API token, as such:
 
 ![Github Personal API Token Page](/images/github-personal-api-token-page.png)
 


### PR DESCRIPTION
When you use a Personal Access Token, a blank password is required interactively. This puts the blank password in the URL instead.  Without this, Capistrano returns:

```
error: The requested URL returned error: 403 Forbidden while accessing https://XXXX....
```
