### PR TITLE
Minor fix to /var/www setup instructions

### DIFF
--- a/documentation/getting-started/authentication-and-authorisation/index.markdown
+++ b/documentation/getting-started/authentication-and-authorisation/index.markdown
@@ -347,6 +347,7 @@ access that you may or may not need depending how well your servers are setup:
     root@remote $ umask 0002
     root@remote $ chmod g+s ${deploy_to}
     root@remote $ mkdir ${deploy_to}/{releases,shared}
+    root@remote $ chown deploy ${deploy_to}/{releases,shared}
 {% endhighlight %}
 
 **Note:** The `chmod g+s` is a really handy, and little known Unix feature, it


### PR DESCRIPTION
${deploy_to}/{releases,shared} are created with root as owner when in fact we want the deploy user to be the owner. An explicit chown fixes that.
