### PR TITLE
Little error fix about groups option

### DIFF
--- a/_posts/2013-06-01-release-announcement.markdown
+++ b/_posts/2013-06-01-release-announcement.markdown
@@ -202,7 +202,7 @@ Other modes for parallelism include:
 
 {% highlight ruby %}
     # Capistrano 3.0.x
-    on :all, in: :groups, max: 3, wait: 5 do
+    on :all, in: :groups, limit: 3, wait: 5 do
       # Take all servers, in groups of three which execute in parallel
       # wait five seconds between groups of servers.
       # This is perfect for rolling restarts


### PR DESCRIPTION
I found `:max` option does not effort at all.

according  to [this code](https://github.com/capistrano/sshkit/blob/e60b80ab13f0df89a9843dbca28c8163509e3c18/lib/sshkit/runners/group.rb#L15) it should be limit. :3
