### PR TITLE
remove deploy:restart from flow documentation

### DIFF
--- a/documentation/getting-started/flow/index.markdown
+++ b/documentation/getting-started/flow/index.markdown
@@ -78,7 +78,6 @@ deploy
       deploy:normalize_assets
   deploy:publishing
     deploy:symlink:release
-    deploy:restart
   deploy:published
   deploy:finishing
     deploy:cleanup
@@ -103,7 +102,6 @@ deploy
       deploy:rollback_assets
   deploy:publishing
     deploy:symlink:release
-    deploy:restart
   deploy:published
   deploy:finishing_rollback
     deploy:cleanup_rollback


### PR DESCRIPTION
because https://github.com/capistrano/capistrano/commit/4e6523e1f50707499cf75eb53dce37a89528a9b0
