### PR TITLE
Update plugins page; add new plugin

### DIFF
--- a/documentation/plugins/index.markdown
+++ b/documentation/plugins/index.markdown
@@ -5,13 +5,14 @@ layout: default
 
 Here are some Capistrano plugins you might find useful.
 
-<div class="github-widget" data-repo="bruno-/capistrano-postgresql"></div>
+<div class="github-widget" data-repo="capistrano-plugins/capistrano-postgresql"></div>
 
-<div class="github-widget" data-repo="bruno-/capistrano-unicorn-nginx"></div>
+<div class="github-widget" data-repo="capistrano-plugins/capistrano-unicorn-nginx"></div>
 
-<div class="github-widget" data-repo="bruno-/capistrano-rbenv-install"></div>
+<div class="github-widget" data-repo="capistrano-plugins/capistrano-rbenv-install"></div>
 
-<div class="github-widget" data-repo="bruno-/capistrano-safe-deploy-to"></div>
+<div class="github-widget" data-repo="capistrano-plugins/capistrano-safe-deploy-to"></div>
 
 <div class="github-widget" data-repo="scottsuch/capistrano-graphite"></div>
 
+<div class="github-widget" data-repo="capistrano-plugins/capistrano-ssh-doctor"></div>


### PR DESCRIPTION
A small update that:
- corrects URL's for a couple plugins. Unfortunately they got broken when repositories were transferred to another github organization.
- adds a link to `capistrano-ssh-doctror` plugin
