### PR TITLE
add git submodules plugin

### DIFF
--- a/documentation/third-party-plugins/index.markdown
+++ b/documentation/third-party-plugins/index.markdown
@@ -19,3 +19,5 @@ This list is neither complete nor audited in any way.
 <div class="github-widget" data-repo="scottsuch/capistrano-graphite"></div>
 
 <div class="github-widget" data-repo="dei79/capistrano-rails-collection"></div>
+
+<div class="github-widget" data-repo="i-ekho/capistrano-git-submodule-strategy"></div>


### PR DESCRIPTION
Since a lot of people keep asking about Git and submodules,
somebody put it into a SCM strategy to be used as Capistrano plugin.
