### PR TITLE
add travis support for HTML checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.1.1
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproof _site

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ source "https://rubygems.org"
 # just do `bundle update` to get the latest version.
 
 gem 'github-pages'
+gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -18,6 +19,9 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorator (0.1)
+    colored (1.2)
+    ethon (0.7.2)
+      ffi (>= 1.3.0)
     execjs (2.2.2)
     fast-stemmer (1.0.2)
     ffi (1.9.6)
@@ -47,6 +51,14 @@ GEM
     html-pipeline (1.9.0)
       activesupport (>= 2)
       nokogiri (~> 1.4)
+    html-proofer (1.6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.6.7)
+      yell (~> 2.0)
     i18n (0.7.0)
     jekyll (2.4.0)
       classifier-reborn (~> 2.0)
@@ -93,8 +105,9 @@ GEM
     mini_portile (0.6.2)
     minitest (5.5.1)
     net-dns (0.8.0)
-    nokogiri (1.6.5)
+    nokogiri (1.6.6.1)
       mini_portile (~> 0.6.0)
+    parallel (1.3.3)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.9)
@@ -115,12 +128,16 @@ GEM
       hitimes
     toml (0.1.2)
       parslet (~> 1.5.0)
+    typhoeus (0.6.9)
+      ethon (>= 0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     yajl-ruby (1.1.0)
+    yell (2.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  html-proofer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-capistranorb.com
-====================
+# capistranorb.com [![Build Status](https://travis-ci.org/capistrano/capistrano.github.io.svg?branch=master)](https://travis-ci.org/capistrano/capistrano.github.io)
 
 Essay style documentation for Capistrano build with Jekyll and Github Pages.
 Send a PR here to contribute docs @ [capistranorb.com](http://capistranorb.com)

--- a/_config.yml
+++ b/_config.yml
@@ -5,4 +5,4 @@ lsi: false
 markdown: redcarpet
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
-exclude: ["Gemfile", "Gemfile.lock", "README.md"]
+exclude: ["CNAME", "Gemfile", "Gemfile.lock", "README.md", "vendor"]


### PR DESCRIPTION
Jekyll CI guide from http://jekyllrb.com/docs/continuous-integration/.
This PR introduces basic HTML checks to see if all links, images, and scripts on are working properly.

@leehambley I think you have to flip a switch over at Travis to enable it.
