### PR TITLE
Fix the before/after hook example

### DIFF
--- a/documentation/getting-started/before-after/index.markdown
+++ b/documentation/getting-started/before-after/index.markdown
@@ -13,11 +13,11 @@ after :finishing, :notify
 
 
 # or define in block
-before :starting, :ensure_user do
+before :starting do
   #
 end
 
-after :finishing, :notify do
+after :finishing do
   #
 end
 ```


### PR DESCRIPTION
Use a task name or a block, but not both.
