### PR TITLE
Migration documentation now mentions difference in cleanup behaviour

### DIFF
--- a/documentation/upgrading/index.markdown
+++ b/documentation/upgrading/index.markdown
@@ -126,3 +126,13 @@ on roles :all do
   end
 end
 ```
+
+# Notable differences between 2.x and 3
+
+#### Cleanup
+
+Capistrano 3 now runs the `deploy:cleanup` task as part of the standard deploy workflow and keeps 5 releases by default. Previously this was left for you to add manually, if required. To change the number of releases kept set the `keep_releases` configuration variable:
+
+```ruby
+set :keep_releases, 10
+```


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/capistrano/a7Kr20xuC2E for background.

Thought the first step should be to add some clear documentation on the differences in behaviour between 2.x and 3.
