### PR TITLE
Ignores Capistrano config files by default when deploying

### DIFF
--- a/documentation/advanced-features/ignoring/index.markdown
+++ b/documentation/advanced-features/ignoring/index.markdown
@@ -1,0 +1,13 @@
+---
+title: Ignoring
+layout: default
+---
+
+Files commited to version control (i.e. not in .gitignore) can still be ignored when  
+deploying.  To ignore these files or directories, simply add them to .gitattributes:  
+```
+config/deploy/deploy.rb   export-ignore  
+config/deploy/            export-ignore
+```  
+  
+These files will be kept in version control but not deployed to the server.  


### PR DESCRIPTION
Capistrano config & task files were ending up on production servers,
which was less than ideal.

Base Capistrano files are now automatically ignored when deploying
via .gitattributes.
