### PR TITLE
Min ruby version is now 2.0 instead of 1.9.3

### DIFF
--- a/documentation/getting-started/installation/index.markdown
+++ b/documentation/getting-started/installation/index.markdown
@@ -3,7 +3,7 @@ title: Installation
 layout: default
 ---
 
-Capistrano is bundled as a Ruby Gem. **It requires Ruby 1.9.3 or newer.**
+Capistrano is bundled as a Ruby Gem. **It requires Ruby 2.0 or newer.**
 
 Capistrano can be installed as a standalone Gem, or bundled into your
 application.


### PR DESCRIPTION
$gem install capistrano
ERROR:  Error installing capistrano:
        net-ssh requires Ruby version >= 2.0.
