### PR TITLE
Basic SSH docs in installation section

### DIFF
--- a/documentation/getting-started/installation/index.markdown
+++ b/documentation/getting-started/installation/index.markdown
@@ -57,6 +57,31 @@ Capfile, after the `require 'capistrano/deploy'` line:
 require 'capistrano/rails'
 ```
 
+##### SSH
+
+Capistrano deploys using SSH. Thus, you must be able to SSH (ideally with keys
+and ssh-agent) from the deployment system to the destination system for
+Capistrano to work.
+
+You can test this using a ssh client, e.g. `ssh myuser@destinationserver`. If
+you cannot connect at all, you may need to set up the SSH server or resolve
+firewall/network issues. Look for a tutorial (here are suggestions for
+[Ubuntu](https://help.ubuntu.com/community/SSH) and
+[RedHat/CentOS](http://www.cyberciti.biz/faq/centos-ssh/)).
+
+If a password is requested when you log in, you may need to set up SSH keys.
+GitHub has a [good tutorial](https://help.github.com/articles/generating-ssh-keys/)
+on creating these (follow steps 1 through 3). You will need to add your public
+key to `~/.ssh/authorized_keys` on the destination server as the deployment user
+(append on a new line).
+
+More information on SSH and login is available via the
+[Authentication and Authorisation](http://capistranorb.com/documentation/getting-started/authentication-and-authorisation/)
+section of the guide.
+
+If you are still struggling to get login working, try the
+[Capistrano SSH Doctor](https://github.com/capistrano-plugins/capistrano-ssh-doctor)
+plugin.
 
 ##### Help! I was using Capistrano `v2.x` and I didn't want to upgrade!
 


### PR DESCRIPTION
In [helping someone on Stack Overflow](https://stackoverflow.com/questions/34470469/error-in-capistrano-deployment-in-localhost/34471823?noredirect=1#comment56763503_34471823) this morning, I realized that the Capistrano docs don't have a basic section that tells someone they need SSH. I've attempted to write a blurb to that end.

I've been answering Stack Overflow questions on Capistrano for a few months now, and I'm trying to become better at pointing people at the official docs when I can, and improving the docs when I can. I hope this is helpful.

Thanks!
