### PR TITLE
Switch from redcarpet to GH-flavored kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 name: Capistrano
+kramdown:
+  input: GFM
+  hard_wrap: false
 highlighter: rouge
 safe: true
 lsi: false
-markdown: redcarpet
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
 exclude: ["Gemfile", "Gemfile.lock", "README.md", "vendor"]


### PR DESCRIPTION
This should fix #172, but it has a side effect of completely changing the syntax highlighting.

Before:
![screen shot 2016-02-12 at 2 36 10 pm](https://cloud.githubusercontent.com/assets/189693/13022385/0c8bcecc-d196-11e5-9317-30dc8ec8ecc6.png)

After:
![screen shot 2016-02-12 at 2 36 23 pm](https://cloud.githubusercontent.com/assets/189693/13022382/0594c394-d196-11e5-8b52-a0fd69f2c814.png)

@leehambley Do you remember enough about the CSS to troubleshoot this? It looks like the syntax highlight classes are completely different, so I don't think it is a quick fix.

At minimum, we should:
- [ ] Add a background color to the code blocks to delineate them
- [ ] Restore the fixed width and overflow: scroll behavior
