### PR TITLE
"No thanks" should apply to entire site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,7 @@
       ga('send', 'event', 'harrowBanner', 'clickthrough');
     });
     $(".harrowBanner__dismissLink").on('click', function (e) {
-      $.cookie('harrowBanner__dismissed', '1', { expires: 10});
+      $.cookie('harrowBanner__dismissed', '1', { path: "/", expires: 10 });
       $('.harrowBanner').hide();
       ga('send', 'event', 'harrowBanner', 'dismiss');
     });


### PR DESCRIPTION
This fixes a bug where dismissing the modal with "no thanks" would hide it for the current page, but the modal would then reappear when navigating to another page.

Fixes #178.
