### PR TITLE
Update to new version of rb-inotify

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       sawyer (~> 0.6.0, >= 0.5.3)
     public_suffix (1.5.3)
     rb-fsevent (0.9.7)
-    rb-inotify (0.9.6)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rdiscount (2.1.8)
     redcarpet (3.3.3)


### PR DESCRIPTION
It looks like rb-inotify 0.9.6 was withdrawn: https://rubygems.org/gems/rb-inotify/versions/0.9.7

Due to this, I can't `bundle install` the docs to run jekyll. This patch appears to fix it.
