### PR TITLE
Change the url of the link to capistrano2 documents

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <ul class="side-nav">
   <li><a href="https://www.harrow.io/hosted-capistrano-for-teams/?utm_source=CAP&utm_medium=BAN&utm_term=00001&utm_campaign=00004&utm_campaign=CAP_BAN_00001_00004#hosted-capistrano-for-teams" title="Harrow | Seamless collaboration for software teams"><span class="label label-important">New</span> Hosted Capistrano for Teams</a></li>
   <li class="divider"></li>
-  
+
   <h5>Search</h5>
   <form action="https://www.google.com/search" method="get">
     <input type="hidden" name="as_sitesearch" value="capistranorb.com">
@@ -70,7 +70,7 @@
   <li class="divider"></li>
 
   <h5>Legacy</h5>
-  <li><a href="https://github.com/capistrano/capistrano/wiki">Capistrano 2 Documentation Wiki</a></li>
+  <li><a href="https://github.com/capistrano/capistrano-2.x-docs/">Capistrano 2 Documentation Repository</a></li>
   <li><a href="/documentation/upgrading/">Upgrading from Capistrano 2.x to 3</a></li>
   <li class="divider"></li>
 


### PR DESCRIPTION
The wiki is turned off (#1646). So, change the url of the link to capistrano2 documents.
