### PR TITLE
Fix misleading code example

### DIFF
--- a/documentation/getting-started/configuration/index.markdown
+++ b/documentation/getting-started/configuration/index.markdown
@@ -20,7 +20,7 @@ Each variable can be set to a specific value:
 set :application, 'MyLittleApplication'
 
 # use a lambda to delay evaluation
-set :application, -> { "SomeThing_#{fetch :other_config}" }
+set :special_thing, -> { "SomeThing_#{fetch :other_config}" }
 ```
 
 A value can be retrieved from the configuration at any time:


### PR DESCRIPTION
You are not allowed to use a lambda for `:application` value, because the `:application` validator expects a string only.
See https://github.com/capistrano/capistrano/blob/848301718570b168ef491974e3ba5b5055d63648/lib/capistrano/defaults.rb#L2
