### PR TITLE
Fix links in Navigation & in Installation page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -43,9 +43,9 @@
   <li><a href="/documentation/advanced-features/role-filtering/">Role Filtering</a></li>
   <li><a href="/documentation/advanced-features/overriding-capistrano-tasks/">Overriding Capistrano Tasks</a></li>
   <li><a href="/documentation/advanced-features/remote-file/">Remote File Task</a></li>
-  <li><a href="/documentation/advanced-features/ssh-kit">Remote Commands with SSHKit</li>
-  <li><a href="/documentation/advanced-features/ignoring">Preventing file deployment with gitattributes</li>
-  <li><a href="/documentation/advanced-features/validation-of-variables">Validation of variables</li>
+  <li><a href="/documentation/advanced-features/ssh-kit">Remote Commands with SSHKit</a></li>
+  <li><a href="/documentation/advanced-features/ignoring">Preventing file deployment with gitattributes</a></li>
+  <li><a href="/documentation/advanced-features/validation-of-variables">Validation of variables</a></li>
   <li class="divider"></li>
 
   <h5>Plugins</h5>

--- a/documentation/getting-started/installation/index.markdown
+++ b/documentation/getting-started/installation/index.markdown
@@ -99,7 +99,6 @@ install `2.15.4`, and any other point-release in the `2.15.x` family without
 the risk of accidentally upgrading to `v3`.
 
 
---
 [rubygems]:                                    http://rubygems.org/
 [rubygems-pessimistic-operator]:               http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 [capistrano-rails-asset-pipeline-readme]:      https://github.com/capistrano/rails/blob/master/README.md


### PR DESCRIPTION
Three of the links in the navigation were missing the closing </a>. 
On the installation page, the 3 dashes were causing the links not to render correctly.
