### PR TITLE
Fix invalid characters in application name example

### DIFF
--- a/documentation/getting-started/preparing-your-application/index.markdown
+++ b/documentation/getting-started/preparing-your-application/index.markdown
@@ -156,7 +156,7 @@ self-documenting, commented-out configuration options, feel free to play with
 them a little:
 
 ```ruby
-  set :application, 'my app name'
+  set :application, 'my_app_name'
   set :repo_url, 'git@example.com:me/my_repo.git'
   ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 ```


### PR DESCRIPTION
Spaces aren't allowed, and underscores appear to be used elsewhere in the documentation.

```
The :application value "my app name" is invalid!
Use only letters, numbers, hyphens, dots, and underscores. For example:
  set :application, 'my_app_name'
(Backtrace restricted to imported tasks)
cap aborted!
Capistrano::ValidationError: Capistrano::ValidationError

Tasks: TOP => live
(See full trace by running task with --trace)
```
